### PR TITLE
Quote `yes` in declarative example YAML

### DIFF
--- a/examples/declarative-example.yaml
+++ b/examples/declarative-example.yaml
@@ -111,11 +111,11 @@ data:
         definition:
           name: some-frontend-name
           type: http
-          forwardfor: yes
+          forwardfor: "yes"
           status: active
           backend_serverpool: some-backend-name
           a_extaddr:
             item:
               - extaddr: wan_ipv4
                 extaddr_port: 443
-                extaddr_ssl: yes
+                extaddr_ssl: "yes"


### PR DESCRIPTION
Yes is interpreted by YAML as a boolean value [1], which prevents the value from syncing to `config.xml` properly. Quoting to force interpretation as a string allows the sync to produce e.g. `<forwardfor>yes</forwardfor>`.

[1]: https://yaml.org/type/bool.html