### PR TITLE
Fix php warning on ingress without host

### DIFF
--- a/src/KubernetesPfSenseController/Plugin/HAProxyIngressProxy.php
+++ b/src/KubernetesPfSenseController/Plugin/HAProxyIngressProxy.php
@@ -230,7 +230,7 @@ class HAProxyIngressProxy extends PfSenseAbstract
 
             foreach ($item['spec']['rules'] as $ruleKey => $rule) {
                 $aclName = $frontend['name'].'-rule-'.$ruleKey;
-                $host = $rule['host'];
+                $host = $rule['host'] ?? '';
                 //$host = "*.${host}"; // for testing purposes only
                 //$host = ""; // for testing purposes only
                 if (!$this->shouldCreateRule($rule)) {
@@ -425,7 +425,7 @@ class HAProxyIngressProxy extends PfSenseAbstract
      */
     private function shouldCreateRule($rule)
     {
-        $hostName = $rule['host'];
+        $hostName = $rule['host'] ?? '';
         $pluginConfig = $this->getConfig();
         if (!empty($pluginConfig['allowedHostRegex'])) {
             $allowed = @preg_match($pluginConfig['allowedHostRegex'], $hostName);


### PR DESCRIPTION
First of all, thanks for a great project!

---

Ingress resources don't necessarily have host defined, f.e. I have this (manually created) ingress resource with only path defined:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: demo-app
spec:
  rules:
  - http:
      paths:
      - backend:
          service:
            name: demo-app
            port:
              name: http
        path: /demo-app
        pathType: Prefix
``` 

But it produces php warnings:

```
PHP Warning:  Undefined array key "host" in phar:///usr/local/bin/kubernetes-pfsense-controller/src/KubernetesPfSenseController/Plugin/HAProxyIngressProxy.php on line 233
PHP Warning:  Undefined array key "host" in phar:///usr/local/bin/kubernetes-pfsense-controller/src/KubernetesPfSenseController/Plugin/HAProxyIngressProxy.php on line 428
``` 

---

I noticed there is also a check for `empty($host)` so we only need to address missing array key here, which I've done here.