### PR TITLE
Return comma separated list of LB IPs not just first

### DIFF
--- a/src/KubernetesPfSenseController/Plugin/DNSIngresses.php
+++ b/src/KubernetesPfSenseController/Plugin/DNSIngresses.php
@@ -126,17 +126,19 @@ class DNSIngresses extends PfSenseAbstract
             return;
         }
 
-        $ip = KubernetesUtils::getIngressIp($ingress);
-        if (empty($ip)) {
+        $ips = KubernetesUtils::getIngressIp($ingress);
+        if (empty($ips)) {
             return;
         }
         foreach ($ingress['spec']['rules'] as $rule) {
             if ($this->shouldCreateHost($rule['host'])) {
                 $resourceHosts[$rule['host']] = [
-                    'ip' => $ip,
+                    'ip' => implode(',', $ips),
                     'resource' => $ingress,
                 ];
-            }
+            } else {
+var_dump("what");
+}
         }
     }
 

--- a/src/KubernetesPfSenseController/Plugin/DNSResourceTrait.php
+++ b/src/KubernetesPfSenseController/Plugin/DNSResourceTrait.php
@@ -69,10 +69,14 @@ trait DNSResourceTrait
 
             if ($dnsmasqEnabled) {
                 $dnsmasqConfig = PfSenseConfigBlock::getRootConfigBlock($this->getController()->getRegistryItem('pfSenseClient'), 'dnsmasq');
+                if (!isset($dnsmasqConfig->data) || !is_array($dnsmasqConfig->data)) {
+                    $dnsmasqConfig->data = [];
+                }
                 if (!isset($dnsmasqConfig->data['hosts']) || !is_array($dnsmasqConfig->data['hosts'])) {
                     $dnsmasqConfig->data['hosts'] = [];
                 }
                 foreach ($hosts as $host) {
+		    $host['ip'] = explode(',', $host['ip'], 2)[0];
                     Utils::putListItemMultiKey($dnsmasqConfig->data['hosts'], $host, ['host', 'domain']);
                 }
 
@@ -87,6 +91,9 @@ trait DNSResourceTrait
 
             if ($unboundEnabled) {
                 $unboundConfig = PfSenseConfigBlock::getRootConfigBlock($this->getController()->getRegistryItem('pfSenseClient'), 'unbound');
+                if (!isset($unboundConfig->data) || !is_array($unboundConfig->data)) {
+                    $unboundConfig->data = [];
+                }
                 if (!isset($unboundConfig->data['hosts']) || !is_array($unboundConfig->data['hosts'])) {
                     $unboundConfig->data['hosts'] = [];
                 }

--- a/src/KubernetesPfSenseController/Plugin/KubernetesUtils.php
+++ b/src/KubernetesPfSenseController/Plugin/KubernetesUtils.php
@@ -197,14 +197,22 @@ class KubernetesUtils
     }
 
     /**
-     * Get IP address of an ingress resource
+     * Get list of IP addresses of an ingress resource as comma-separated string
      *
      * @param $ingress
      * @return mixed
      */
     public static function getIngressIp($ingress)
     {
-        return $ingress['status']['loadBalancer']['ingress'][0]['ip'];
+        return implode(
+            ',',
+            array_map(
+                function ($lbIngress) {
+                    return $lbIngress['ip'];
+                },
+                $ingress['status']['loadBalancer']['ingress'];
+            )
+        );
     }
 
     /**

--- a/src/KubernetesPfSenseController/Plugin/KubernetesUtils.php
+++ b/src/KubernetesPfSenseController/Plugin/KubernetesUtils.php
@@ -204,14 +204,11 @@ class KubernetesUtils
      */
     public static function getIngressIp($ingress)
     {
-        return implode(
-            ',',
-            array_map(
-                function ($lbIngress) {
-                    return $lbIngress['ip'];
-                },
-                $ingress['status']['loadBalancer']['ingress'];
-            )
+        return array_map(
+            function ($lbIngress) {
+                return $lbIngress['ip'];
+            },
+            $ingress['status']['loadBalancer']['ingress']
         );
     }
 


### PR DESCRIPTION
* Set unbound IP as comma separated list of LB IPs not just first
* Keep first IP behavior for dnsmasq
* Fix bug if no hosts are set in dnsmasq or unbound

Addresses #27 

Demoed changes on https://onlinephp.io/c/ae9bb, and building locally. As mentioned, open to making this a setting, but I think all pfSense versions except those with the bug linked in #27 should accept a comma-separated list.

Slightly messy with implode/explode, but I didn't want to change the struct being used too much.